### PR TITLE
Compiles with Clang

### DIFF
--- a/libvoikko/src/grammar/VoikkoGrammarError.hpp
+++ b/libvoikko/src/grammar/VoikkoGrammarError.hpp
@@ -35,7 +35,7 @@
 
 namespace libvoikko { namespace grammar {
 
-struct GrammarChecker;
+class GrammarChecker;
 
 class VoikkoGrammarError {
 


### PR DESCRIPTION
Looks like Clang is stricter than GCC regarding structs and classes.
