### PR TITLE
Makes Voikko compile on OS X Mavericks.

### DIFF
--- a/libvoikko/src/grammar/FinnishAnalysis.cpp
+++ b/libvoikko/src/grammar/FinnishAnalysis.cpp
@@ -35,7 +35,7 @@
 #include <cstring>
 
 using namespace libvoikko::grammar;
-using namespace std;
+using std::list;
 
 namespace libvoikko {
 

--- a/libvoikko/src/grammar/FinnishRuleEngine.cpp
+++ b/libvoikko/src/grammar/FinnishRuleEngine.cpp
@@ -37,8 +37,6 @@
 
 using namespace libvoikko::autocorrect;
 
-using namespace std;
-
 namespace libvoikko { namespace grammar {
 
 FinnishRuleEngine::FinnishRuleEngine(voikko_options_t * voikkoOptions) :

--- a/libvoikko/src/grammar/FinnishRuleEngine/CapitalizationCheck.cpp
+++ b/libvoikko/src/grammar/FinnishRuleEngine/CapitalizationCheck.cpp
@@ -36,7 +36,8 @@
 
 using namespace libvoikko::character;
 using namespace libvoikko::utils;
-using namespace std;
+using std::list;
+using std::stack;
 
 namespace libvoikko { namespace grammar { namespace check {
 

--- a/libvoikko/src/grammar/FinnishRuleEngine/MissingVerbCheck.cpp
+++ b/libvoikko/src/grammar/FinnishRuleEngine/MissingVerbCheck.cpp
@@ -30,8 +30,6 @@
 #include "character/SimpleChar.hpp"
 #include "grammar/error.hpp"
 
-using namespace std;
-
 namespace libvoikko { namespace grammar { namespace check {
 
 void MissingVerbCheck::check(voikko_options_t * options, const Sentence * sentence) {

--- a/libvoikko/src/grammar/HfstAnalysis.cpp
+++ b/libvoikko/src/grammar/HfstAnalysis.cpp
@@ -44,7 +44,6 @@
 #include <vector>
 
 using namespace libvoikko::grammar;
-using namespace std;
 using namespace hfst_ol;
 //using namespace hfst;
 

--- a/libvoikko/src/hyphenator/AnalyzerToFinnishHyphenatorAdapter.cpp
+++ b/libvoikko/src/hyphenator/AnalyzerToFinnishHyphenatorAdapter.cpp
@@ -34,7 +34,7 @@
 
 using namespace libvoikko::morphology;
 using namespace libvoikko::character;
-using namespace std;
+using std::list;
 
 namespace libvoikko { namespace hyphenator {
 

--- a/libvoikko/src/spellchecker/FinnishSpellerTweaksWrapper.cpp
+++ b/libvoikko/src/spellchecker/FinnishSpellerTweaksWrapper.cpp
@@ -32,7 +32,7 @@
 #include "character/SimpleChar.hpp"
 #include "utils/utils.hpp"
 
-using namespace std;
+using std::list;
 using namespace libvoikko::morphology;
 using namespace libvoikko::character;
 

--- a/libvoikko/src/spellchecker/suggestion/SuggestionGeneratorSoftHyphens.cpp
+++ b/libvoikko/src/spellchecker/suggestion/SuggestionGeneratorSoftHyphens.cpp
@@ -32,7 +32,6 @@
 #include <cwchar>
 
 using namespace libvoikko::morphology;
-using namespace std;
 
 namespace libvoikko { namespace spellchecker { namespace suggestion {
 

--- a/libvoikko/src/utils/StringUtils.cpp
+++ b/libvoikko/src/utils/StringUtils.cpp
@@ -32,8 +32,6 @@
 #include <cstdlib>
 #include <cwchar>
 
-using namespace std;
-
 namespace libvoikko { namespace utils {
 
 wchar_t * StringUtils::ucs4FromUtf8(const char * const original) {


### PR DESCRIPTION
The problem was, including both <wchar.h> and <cwchar> and then using
'using namespace std' caused ambiguous versions of wchar functions
to be imported to default scope. For some reason the version of Clang
included with Mavericks is stricter about this.
