### PR TITLE
Fixes for building with clang

### DIFF
--- a/libvoikko/src/grammar/FinnishRuleEngine/VfstAutocorrectCheck.cpp
+++ b/libvoikko/src/grammar/FinnishRuleEngine/VfstAutocorrectCheck.cpp
@@ -100,7 +100,7 @@ bool VfstAutocorrectCheck::check(voikko_options_t * options, const Sentence * se
 				return false; // sentence is unreasonably long
 			}
 			for (size_t i = 0; i < token->tokenlen; i++) {
-				if (wcschr(L"\u00AD", tokenStr[i])) {
+				if (::wcschr(L"\u00AD", tokenStr[i])) {
 					skippedChars++;
 				}
 				else {

--- a/libvoikko/src/morphology/Analysis.cpp
+++ b/libvoikko/src/morphology/Analysis.cpp
@@ -28,12 +28,13 @@
 
 #include "morphology/Analysis.hpp"
 #include "utils/StringUtils.hpp"
+#include <array>
 
 using namespace libvoikko::utils;
 
 namespace libvoikko { namespace morphology {
 
-static constexpr std::array<const char *,21> KEY_TO_STRING {
+static const std::array<const char *,21> KEY_TO_STRING { {
 	"BASEFORM",
 	"CLASS",
 	"COMPARISON",
@@ -55,7 +56,7 @@ static constexpr std::array<const char *,21> KEY_TO_STRING {
 	"WEIGHT",
 	"WORDBASES",
 	"WORDIDS"
-};
+} };
 
 static const std::map<std::string, Analysis::Key> STRING_TO_KEY = {
 	{"BASEFORM", Analysis::Key::BASEFORM},


### PR DESCRIPTION
- ambiguous wcschr fixed to ::wcschr
- initialization of std::array changed for stricter checking