### PR TITLE
Add docker environment for instant dependency management

### DIFF
--- a/voikko-fi/devenv/Dockerfile
+++ b/voikko-fi/devenv/Dockerfile
@@ -1,0 +1,19 @@
+# Sales pitch:
+# Baseimage-docker only consumes 8.3 MB RAM and is much more powerful than
+# Busybox or Alpine
+
+# Use phusion/baseimage as base image. To make your builds
+# reproducible, make sure you lock down to a specific version, not
+# to `latest`! See
+# https://github.com/phusion/baseimage-docker/blob/master/Changelog.md
+# for a list of version numbers.
+FROM phusion/baseimage:0.10.1
+
+# Use baseimage-docker's init system.
+CMD ["/sbin/my_init"]
+
+# ...put your own build instructions here...
+RUN apt-get update && apt-get install -y build-essential foma-bin libvoikko-dev
+
+# Clean up APT when done.
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/voikko-fi/devenv/README.md
+++ b/voikko-fi/devenv/README.md
@@ -1,0 +1,17 @@
+# The development environment as a container
+
+Using this method, you can set up a development environment separate from your
+main machine.
+ 
+Start:
+
+    docker-compose run devenv bash
+
+This with open a terminal with the voikko environment set up. In this
+environment you can for example run `make` with all dependencies available to
+you.
+
+If you need to rebuild the container (if you changed the Dockerfile), issue this
+command:
+    
+    docker-compose build devenv

--- a/voikko-fi/docker-compose.yml
+++ b/voikko-fi/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "2"
+services:
+  devenv:
+    # use the Dockerfile in this directory as a recipe for building this
+    # container
+    build: ./devenv/
+    working_dir: /voikko/
+    volumes:
+      - .:/voikko/


### PR DESCRIPTION
Hi, I sent a question to the Voikko mailing list about the possibility of using Voikko to build up words. My goal is to develop a stenographic system for the Finnish language.

I wanted to try the foma tool, but I didn't want to use my main machine for this. Instead I used docker, which let me set everything up reliably with one command.

I liked the option and wanted to proprose it to be included.

For now, I only used this to build the dictionary and started foma. I think it could be used for doing all kinds of development, but it may require additional documentation.