### PR TITLE
Fail build when foma segfaults

### DIFF
--- a/voikko-fi/Makefile
+++ b/voikko-fi/Makefile
@@ -120,6 +120,7 @@ $(VVFST_BUILDDIR)/autocorrect.foma: vvfst/autocorrect.foma.in
 
 $(VVFST_BUILDDIR)/all.att: $(VVFST_BUILDDIR)/all.lexc $(VVFST_BUILDDIR)/main.foma
 	foma -f $(VVFST_BUILDDIR)/main.foma 2>&1 | grep -v "defined but not used"
+	test -e $@
 	! grep ']]' $@
 
 $(VVFST_BUILDDIR)/autocorrect.att: $(VVFST_BUILDDIR)/autocorrect.lexc $(VVFST_BUILDDIR)/autocorrect.foma


### PR DESCRIPTION
https://bugzilla.opensuse.org/show_bug.cgi?id=1109949

Without this patch, (on i586) a mor.vfst of 19 bytes was created
and build succeeded, which let the foma segfault remain unnoticed for a long time.

This bug was found while working on reproducible builds for openSUSE.