### PR TITLE
Fix memory leak in hyphenation

### DIFF
--- a/libvoikko/src/hyphenator/interface.cpp
+++ b/libvoikko/src/hyphenator/interface.cpp
@@ -115,6 +115,7 @@ VOIKKOEXPORT char * voikkoInsertHyphensCstr(voikko_options_t * options, const ch
 	// Clean up and return the result
 	delete[] hyphen_ucs4;
 	delete[] word_ucs4;
+  delete[] hyphenationPattern;
 	return utils::StringUtils::utf8FromUcs4(hyphenated.str().c_str());
 }
 

--- a/libvoikko/src/hyphenator/interface.cpp
+++ b/libvoikko/src/hyphenator/interface.cpp
@@ -115,7 +115,7 @@ VOIKKOEXPORT char * voikkoInsertHyphensCstr(voikko_options_t * options, const ch
 	// Clean up and return the result
 	delete[] hyphen_ucs4;
 	delete[] word_ucs4;
-  delete[] hyphenationPattern;
+	delete[] hyphenationPattern;
 	return utils::StringUtils::utf8FromUcs4(hyphenated.str().c_str());
 }
 


### PR DESCRIPTION
There seems to be a small memory leak `voikkoInsertHyphensCstr` function.

I was unable to build and test the fix, but `hyphenationPattern` seems like the obvious culprit.